### PR TITLE
seulex_alg_order_fix

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -28,7 +28,7 @@ struct seulex{T} <: ODEInterfaceImplicitAlgorithm
     jac_lower::T
     jac_upper::T
 end
-SciMLBase.alg_order(alg::odex) = 12
+SciMLBase.alg_order(alg::seulex) = 12
 
 
 """


### PR DESCRIPTION
Guess at a fix for https://github.com/SciML/ODEInterfaceDiffEq.jl/issues/58 :

Probable typo in 

    SciMLBase.alg_order(alg::seulex)

method definition

NB: not checked whether alg_order for seulex is correct for this implementation - the implementation in https://dx.doi.org/10.1016/j.combustflame.2016.09.018 uses up to 12th order